### PR TITLE
Package maintenance: v1.0.0 bump and cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.jl.mem
 deps/deps.jl
 Manifest.toml
+Manifest-v*.toml

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegisterWorkerAperturesMismatch"
 uuid = "30e56b64-2659-11e9-2fbf-0524297743d8"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "0.2.4"
+version = "1.0.0"
 
 [deps]
 CoordinateTransformations = "150eb455-5306-5404-9cee-2592286d6298"

--- a/src/RegisterWorkerAperturesMismatch.jl
+++ b/src/RegisterWorkerAperturesMismatch.jl
@@ -6,7 +6,7 @@ using RegisterMismatch, RegisterMismatchCommon
 # Note: RegisterMismatchCuda is loaded dynamically below when dev >= 0
 using RegisterWorkerShell # , RegisterDriver
 
-import RegisterWorkerShell: worker, init!, close!, load_mm_package
+import RegisterWorkerShell: worker, init!, close!, load_mm_package, workertid
 
 export AperturesMismatch, monitor, monitor!, worker
 
@@ -22,10 +22,12 @@ mutable struct AperturesMismatch{A<:AbstractArray,T,K,N} <: AbstractWorker
     cs
     Qs
     mmis
-    workertid::Int
+    tid::Int
     dev::Int
     cuda_objects::Dict{Symbol,Any}
 end
+
+workertid(w::AperturesMismatch) = w.tid
 
 function load_mm_package(dev)
     if dev >= 0

--- a/src/RegisterWorkerAperturesMismatch.jl
+++ b/src/RegisterWorkerAperturesMismatch.jl
@@ -111,7 +111,7 @@ pre-processing function, but see also `PreprocessSNF`.
 ```
 
 """
-function AperturesMismatch(fixed, nodes::NTuple{N,K}, maxshift, preprocess=identity; normalization=:pixels, thresh_fac=(0.5)^ndims(fixed), thresh=nothing, correctbias::Bool=true, tid=1, dev=-1) where {K,N}
+function AperturesMismatch(fixed, nodes::NTuple{N,K}, maxshift::NTuple{N,<:Integer}, preprocess=identity; normalization=:pixels, thresh_fac=(0.5)^ndims(fixed), thresh=nothing, correctbias::Bool=true, tid=1, dev=-1) where {K,N}
     gridsize = map(length, nodes)
     nimages(fixed) == 1 || error("Register to a single image")
     if isnothing(thresh)

--- a/src/RegisterWorkerAperturesMismatch.jl
+++ b/src/RegisterWorkerAperturesMismatch.jl
@@ -3,7 +3,7 @@ module RegisterWorkerAperturesMismatch
 using ImageCore, CoordinateTransformations, Interpolations, StaticArrays, SharedArrays
 using RegisterCore, RegisterDeformation, RegisterFit, RegisterPenalty, RegisterOptimize
 using RegisterMismatch, RegisterMismatchCommon
-# Note: RegisterMismatchCuda is loaded dynamically below when dev >= 0
+# Note: RegisterMismatchCuda is loaded dynamically below when dev !== nothing
 using RegisterWorkerShell # , RegisterDriver
 
 import RegisterWorkerShell: worker, init!, close!, load_mm_package, workertid
@@ -23,21 +23,21 @@ mutable struct AperturesMismatch{A<:AbstractArray,T,K,N} <: AbstractWorker
     Qs
     mmis
     tid::Int
-    dev::Int
+    dev::Union{Nothing,Int}
     cuda_objects::Dict{Symbol,Any}
 end
 
 workertid(w::AperturesMismatch) = w.tid
 
 function load_mm_package(dev)
-    if dev >= 0
+    if dev !== nothing
         eval(:(using CUDA, RegisterMismatchCuda))
     end
     nothing
 end
 
 function init!(algorithm::AperturesMismatch)
-    if algorithm.dev >= 0
+    if algorithm.dev !== nothing
         cuda_init!(algorithm)
     end
     nothing
@@ -66,8 +66,8 @@ function cuda_init!(algorithm)
 end
 
 function close!(algorithm::AperturesMismatch)
-    if algorithm.dev >= 0
-        if old_active_context != nothing
+    if algorithm.dev !== nothing
+        if !isnothing(old_active_context)
             activate(old_active_context)
         end
     end
@@ -113,7 +113,7 @@ pre-processing function, but see also `PreprocessSNF`.
 ```
 
 """
-function AperturesMismatch(fixed, nodes::NTuple{N,K}, maxshift::NTuple{N,<:Integer}, preprocess=identity; normalization=:pixels, thresh_fac=(0.5)^ndims(fixed), thresh=nothing, correctbias::Bool=true, tid=1, dev=-1) where {K,N}
+function AperturesMismatch(fixed, nodes::NTuple{N,K}, maxshift::NTuple{N,<:Integer}, preprocess=identity; normalization=:pixels, thresh_fac=(0.5)^ndims(fixed), thresh=nothing, correctbias::Bool=true, tid=1, dev=nothing) where {K,N}
     gridsize = map(length, nodes)
     nimages(fixed) == 1 || error("Register to a single image")
     if isnothing(thresh)
@@ -133,7 +133,7 @@ function worker(algorithm::AperturesMismatch, img, tindex, mon)
     moving0 = getindex_t(img, tindex)
     moving = algorithm.preprocess(moving0)
     gridsize = map(length, algorithm.nodes)
-    use_cuda = algorithm.dev >= 0
+    use_cuda = algorithm.dev !== nothing
     if use_cuda
         device!(CuDevice(algorithm.dev))
         d_fixed  = algorithm.cuda_objects[:d_fixed]

--- a/src/RegisterWorkerAperturesMismatch.jl
+++ b/src/RegisterWorkerAperturesMismatch.jl
@@ -114,7 +114,7 @@ pre-processing function, but see also `PreprocessSNF`.
 function AperturesMismatch(fixed, nodes::NTuple{N,K}, maxshift, preprocess=identity; normalization=:pixels, thresh_fac=(0.5)^ndims(fixed), thresh=nothing, correctbias::Bool=true, tid=1, dev=-1) where {K,N}
     gridsize = map(length, nodes)
     nimages(fixed) == 1 || error("Register to a single image")
-    if thresh == nothing
+    if isnothing(thresh)
         thresh = (thresh_fac/prod(gridsize)) * (normalization==:pixels ? length(fixed) : sumabs2(fixed))
     end
     T = eltype(fixed) <: AbstractFloat ? eltype(fixed) : Float32

--- a/test/internals.jl
+++ b/test/internals.jl
@@ -4,3 +4,10 @@
     @test RegisterWorkerAperturesMismatch.cudatype(Int32) == Float32
     @test RegisterWorkerAperturesMismatch.cudatype(UInt8) == Float32
 end
+
+@testset "AperturesMismatch constructor argument validation" begin
+    fixed = rand(Float32, 20, 20)
+    nodes = (range(1, stop=20, length=4), range(1, stop=20, length=4))
+    # Vector maxshift should not match the NTuple{N,<:Integer} signature
+    @test_throws MethodError AperturesMismatch(fixed, nodes, [3, 3])
+end


### PR DESCRIPTION
## Summary

- Bump version to 1.0.0
- Change `dev` field from `Int` sentinel to `Union{Nothing,Int}`
- Rename `workertid` field to `tid`, add `workertid` accessor overload
- Annotate `maxshift` as `NTuple{N,<:Integer}`, add constructor validation test
- Use `isnothing` instead of `== nothing` for thresh check
- Add `Manifest-v*.toml` to `.gitignore`

## Test plan

- [x] All existing tests pass (`Pkg.test()`)
- [x] Constructor validation test added for `maxshift` annotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)